### PR TITLE
Add PROJECT_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This Action for [firebase-tools](https://github.com/firebase/firebase-tools) ena
 
 * `PROJECT_ID` - **Optional**. To specify a specific project to use for all commands, not required if you specify a project in your `.firebaserc` file.
 
+* `PROJECT_PATH` - **Optional**. The path to `firebase.json` if it doesn't exist at the root of your repository. e.g. `./my-app`
+
 ## Example
 
 To authenticate with Firebase, and deploy to Firebase Hosting:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,8 @@ if [ -n "$PROJECT_ID" ]; then
     firebase use --add $PROJECT_ID
 fi
 
+if [ -n "$PROJECT_PATH" ]; then
+    cd $PROJECT_PATH
+fi
+
 sh -c "firebase $*"


### PR DESCRIPTION
I'm raising this PR on behalf of someone I helped out on Stackoverflow. You can read the full details of the issue here: https://stackoverflow.com/questions/58352402/how-to-add-working-directory-to-deployment-in-github-actions

Basically, `firebase.json` did not exist at the root of the user's repository. So I added an environment variable to set the path.