### PR TITLE
CD to project path before firebase use

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,13 +7,13 @@ if [ -z "$FIREBASE_TOKEN" ]; then
     exit 126
 fi
 
+if [ -n "$PROJECT_PATH" ]; then
+    cd $PROJECT_PATH
+fi
+
 if [ -n "$PROJECT_ID" ]; then
     echo "setting firebase project to $PROJECT_ID"
     firebase use --add $PROJECT_ID
-fi
-
-if [ -n "$PROJECT_PATH" ]; then
-    cd $PROJECT_PATH
 fi
 
 sh -c "firebase $*"


### PR DESCRIPTION
This moves the CD to project path before the `firebase use` is executed. I verified this fixes #9 and I was able to deploy firebase successfully with this change.

