### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,13 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy --only hosting:prod
+          args: deploy --only hosting
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 ```
+
+If you have multiple hosting environments you can specify which one in the args line. 
+e.g. `args: deploy --only hosting:[environment name]`
 
 ## License
 


### PR DESCRIPTION
Fixes firebase deploy line for instances with only one environment not named "prod". Also added instructions for adding a custom environment name to that deploy command.