### PR TITLE
add JDK to firebase-action to be able to run firestore emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
 FROM node:10-slim
 
 LABEL version="1.1.0"
-LABEL repository="https://github.com/w9jds/firebase-action"
-LABEL homepage="https://github.com/w9jds/firebase-action"
-LABEL maintainer="Jeremy Shore <w9jds@github.com>"
+LABEL repository="https://github.com/fulfillmenttools/firebase-action"
+LABEL homepage="https://github.com/fulfillmenttools/firebase-action"
+LABEL maintainer="OC Fulfillment Team"
 
-LABEL com.github.actions.name="GitHub Action for Firebase"
+LABEL com.github.actions.name="GitHub Action for Firebase with JDK"
 LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable common commands."
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
+ENV JAVA_HOME="~/jdk"
+ENV PATH="${PATH}:${JAVA_HOME}/bin"
+
+RUN apt-get update && apt-get install -y wget
 RUN npm install -g firebase-tools
+RUN mkdir -p ~/jdk/ && wget -qO- https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jre_x64_linux_hotspot_13.0.2_8.tar.gz | tar xvz -C ~/jdk --strip-components=1
+
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:10-slim
 
 LABEL version="1.1.0"
-LABEL repository="https://github.com/fulfillmenttools/firebase-action"
-LABEL homepage="https://github.com/fulfillmenttools/firebase-action"
-LABEL maintainer="OC Fulfillment Team"
+LABEL repository="https://github.com/w9jds/firebase-action"
+LABEL homepage="https://github.com/w9jds/firebase-action"
+LABEL maintainer="Jeremy Shore <w9jds@github.com>"
 
 LABEL com.github.actions.name="GitHub Action for Firebase with JDK"
 LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable common commands."

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable com
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
-ENV JAVA_HOME="~/jdk"
+ENV JAVA_HOME="/opt/jdk"
 ENV PATH="${PATH}:${JAVA_HOME}/bin"
 
 RUN apt-get update && apt-get install -y wget
 RUN npm install -g firebase-tools
-RUN mkdir -p ~/jdk/ && wget -qO- https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13.0.2%2B8/OpenJDK13U-jre_x64_linux_hotspot_13.0.2_8.tar.gz | tar xvz -C ~/jdk --strip-components=1
+RUN mkdir -p ${JAVA_HOME} && wget -qO- https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz | tar xvz -C ${JAVA_HOME} --strip-components=1
 
 
 COPY LICENSE README.md /

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: 'GitHub Action for Firebase with JDK'
-author: 'OC Fulfillment Team'
+author: 'Jeremy Shore'
 description: 'Wraps the firebase-tools CLI and JDK to enable common commands and run firebase emulator.'
 branding:
   icon: 'package'

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
-name: 'GitHub Action for Firebase'
-author: 'Jeremy Shore'
-description: 'Wraps the firebase-tools CLI to enable common commands.'
+name: 'GitHub Action for Firebase with JDK'
+author: 'OC Fulfillment Team'
+description: 'Wraps the firebase-tools CLI and JDK to enable common commands and run firebase emulator.'
 branding:
   icon: 'package'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,4 +23,4 @@ if [ -n "$PROJECT_ID" ]; then
     firebase use --add "$PROJECT_ID"
 fi
 
-sh -c "firebase $*"
+sh -c "$*"


### PR DESCRIPTION
firestore emulator needs a jdk installed in the environment.
This PR pulls the adoptopenjdk, installs it and provides env variables in order to be able to run
`firebase emulators:exec` and
`firebase emulators:start`