### PR TITLE
Use specific version of firebase-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL com.github.actions.color="gray-dark"
 # git is now required when install firebase-tools
 RUN apk update && apk upgrade && apk add --no-cache git
 
-RUN npm install -g firebase-tools
+RUN npm install -g firebase-tools@v8.12.1
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"


### PR DESCRIPTION
The recent update of firebase-tools (v8.13.1) caused an error in this action:
Error: Hosting target (project-name) not detected in firebase.json

Setting a version to the firebase-tools avoids the newest release from being used, thus avoiding issues like this one.