### PR TITLE
Run action from prebuilt image

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: docker build & push
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout scm
+        uses: actions/checkout@v2
+      - name: docker/build-push
+        uses: docker/build-push-action@v1
+        with:
+          username: w9jds
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: w9jds/firebase-action
+          tags: latest

--- a/action.yaml
+++ b/action.yaml
@@ -6,4 +6,4 @@ branding:
   color: 'gray-dark'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://w9jds/firebase-action:latest'


### PR DESCRIPTION
@w9jds This should solve slow build times seen in #67 if we allow the image to be built and published to dockerhub.

The only thing that you'd need to do is stick in a `DOCKER_PASSWORD` secret to the repo.