### PR TITLE
Semantic clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If your only doing Hosting `Firebase Hosting Admin` is enough.
 
 * `PROJECT_ID` - **Optional**. To specify a specific project to use for all commands, not required if you specify a project in your `.firebaserc` file.
 
-* `PROJECT_PATH` - **Optional**. The path to `firebase.json` if it doesn't exist at the root of your repository. e.g. `./my-app`
+* `PROJECT_PATH` - **Optional**. The path to the folder containing `firebase.json` if it doesn't exist at the root of your repository. e.g. `./my-app`
 
 ## Example
 


### PR DESCRIPTION
The `PROJECT_PATH` gave the impression the value was for the `firebase.json` file itself. Clarified that it should be the directory.