### PR TITLE
Check for base64 encoding and display error message

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,11 @@ fi
 
 if [ -n "$GCP_SA_KEY" ]; then
   echo "Storing GCP_SA_KEY in /opt/gcp_key.json"
+  CHECK_ENCODING=$(echo "$GCP_SA_KEY" | base64 -d &>/dev/null; echo $?)
+  if [ "$CHECK_ENCODING" -ne 0 ]; then
+    echo "Error: GCP_SA_KEY must be base64 encoded."
+    exit 1
+  fi
   echo "$GCP_SA_KEY" | base64 -d > /opt/gcp_key.json
   echo "Exporting GOOGLE_APPLICATION_CREDENTIALS=/opt/gcp_key.json"
   export GOOGLE_APPLICATION_CREDENTIALS=/opt/gcp_key.json


### PR DESCRIPTION
When I used this action for the first time I didn’t notice that `GCP_SA_KEY` is required to be base64 encoded. My build failed because I provided the service account key as is. It took me a while to figure out the problem, because there was no clear error description in the output that indicated what went wrong.

This PR introduces a pre-check of the text encoding and displays a helpful error message before failing.

## After
<img width="840" alt="Screenshot 2020-12-12 at 12 05 10" src="https://user-images.githubusercontent.com/3618384/101982162-4b2b4f80-3c72-11eb-94bb-4146618aa1d1.png">

## Before
<img width="873" alt="Screenshot 2020-12-12 at 12 15 16" src="https://user-images.githubusercontent.com/3618384/101982367-b9bcdd00-3c73-11eb-829e-6b9aa8452345.png">

(As a side note, I’m not sure why base64 encoding is even required. Could also be made optional by checking the encoding and then taking the value as is or decode it. Happy to add another PR on request.)