### PR TITLE
Update to node:14.17.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.1-alpine
+FROM node:14.17.1-alpine
 
 LABEL version="1.2.1"
 LABEL repository="https://github.com/w9jds/firebase-action"


### PR DESCRIPTION
Proposed changes:
- Update to node:14.17.1-alpine from node:12.22.1-alpine

Node.js 14 is GA now and is the default. References:

- https://github.com/firebase/firebase-tools/pull/3360
- https://github.com/firebase/firebase-tools/pull/3399