### PR TITLE
Fix no installation candidate for JRE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable com
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
-RUN apt update && apt install -y openjdk-8-jre-headless git && apt autoremove --purge -y && apt clean -y
+RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN apt update && apt install -y software-properties-common
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+RUN apt update && apt install -y adoptopenjdk-8-hotspot-jre git && apt autoremove --purge -y && apt clean -y
 
 RUN npm i -g npm@7.19.1
 RUN npm i -g firebase-tools@9.14.0


### PR DESCRIPTION
Fixes https://github.com/w9jds/firebase-action/pull/100#issuecomment-877767706

@w9jds I installed Docker and tested this. Works perfectly. The build should be successful now.