### PR TITLE
Add Docker CI

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -1,0 +1,13 @@
+name: Docker CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile


### PR DESCRIPTION
This CI analyses PRs for build failures. Helpful for catching PRs such as:
- https://github.com/w9jds/firebase-action/pull/99
- https://github.com/w9jds/firebase-action/pull/100

And validating fixes the same such as:
- https://github.com/w9jds/firebase-action/pull/101 (If this is merged, build will pass)