### PR TITLE
update firebase-tools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
 RUN apt update && apt install -y adoptopenjdk-8-hotspot-jre git && apt autoremove --purge -y && apt clean -y
 
 RUN npm i -g npm@7.19.1
-RUN npm i -g firebase-tools@9.16.5
+RUN npm i -g firebase-tools@9.18.0
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
 RUN apt update && apt install -y adoptopenjdk-8-hotspot-jre git && apt autoremove --purge -y && apt clean -y
 
 RUN npm i -g npm@7.19.1
-RUN npm i -g firebase-tools@9.14.0
+RUN npm i -g firebase-tools@9.16.5
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"


### PR DESCRIPTION
this is necessary to get ES modules working with firebase deploys.

support for ES modules was added in 19.15.0: https://github.com/firebase/firebase-tools/releases/tag/v9.15.0

latest version is 9.16.5