### PR TITLE
Use jq to validate a json instead of checking base64 encoded string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL com.github.actions.color="gray-dark"
 RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
 RUN apt update && apt install -y software-properties-common
 RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-RUN apt update && apt install -y adoptopenjdk-8-hotspot-jre git && apt autoremove --purge -y && apt clean -y
+RUN apt update && apt install -y jq adoptopenjdk-8-hotspot-jre git && apt autoremove --purge -y && apt clean -y
 
 RUN npm i -g npm@7.19.1
 RUN npm i -g firebase-tools@9.21.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,15 +8,12 @@ if [ -z "$FIREBASE_TOKEN" ] && [ -z "$GCP_SA_KEY" ]; then
 fi
 
 if [ -n "$GCP_SA_KEY" ]; then
-  BASE64_PATTERN="([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)"
-
-  # If encoded base64 key, decode and save
-  if [[ "$GCP_SA_KEY" =~ $BASE64_PATTERN ]]; then
-    echo "Storing the decoded GCP_SA_KEY in /opt/gcp_key.json"
-    echo "$GCP_SA_KEY" | base64 -d > /opt/gcp_key.json
-  else
+  if echo "$GCP_SA_KEY" | jq empty 2>/dev/null; then
     echo "Storing GCP_SA_KEY in /opt/gcp_key.json"
     echo "$GCP_SA_KEY" > /opt/gcp_key.json
+  else
+    echo "Storing the decoded GCP_SA_KEY in /opt/gcp_key.json"
+    echo "$GCP_SA_KEY" | base64 -d > /opt/gcp_key.json # If encoded base64 key, decode and save
   fi
 
   echo "Exporting GOOGLE_APPLICATION_CREDENTIALS=/opt/gcp_key.json"


### PR DESCRIPTION
Ref: https://github.com/w9jds/firebase-action/issues/119

```bash
set -e

BASE64_PATTERN="([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)"

base64_1=`echo 'foo' | base64` # Zm9vCg==
base64_2=`echo 'fooo' | base64` # Zm9vbwo=
base64_3=`echo 'foooo' | base64` # Zm9vb28K

if [[ $base64_1 =~ $BASE64_PATTERN ]]; then
    echo "matched base64_1"
fi

if [[ $base64_2 =~ $BASE64_PATTERN ]]; then
    echo "matched base64_2"
fi

if [[ $base64_3 =~ $BASE64_PATTERN ]]; then
    echo "matched base64_3"
fi
```

```bash
❯ sh test.sh
matched base64_1
matched base64_2
```

current `BASE64_PATTERN` doesn't match when `=` is missing.
How about validating if given string is json or not? 

```bash
❯ GCP_SA_KEY=`cat gcp_sa_key.json` sh a.sh
Storing GCP_SA_KEY in /opt/gcp_key.json
❯ GCP_SA_KEY=`cat gcp_sa_key.json | base64` sh a.sh
Storing the decoded GCP_SA_KEY in /opt/gcp_key.json
```