### PR TITLE
update firebase-tools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
 RUN apt update && apt install -y jq adoptopenjdk-8-hotspot-jre git && apt autoremove --purge -y && apt clean -y
 
 RUN npm i -g npm@8.3.1
-RUN npm i -g firebase-tools@10.2.1
+RUN npm i -g firebase-tools@10.7.1
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"


### PR DESCRIPTION
Hi, it'd be great if you accepted this PR, as my project needs an updated version of firebase-tools.

Specifically, we need a bug fix where functions' memory configurations weren't preserved in batched function deploys.
See https://github.com/firebase/firebase-tools/releases/tag/v10.3.0.

BTW, latest version of the package is 10.7.1, so I just went ahead with that one. Thx!