### PR TITLE
Remove shell wrapper

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ if [ -n "$CONFIG_VALUES" ]; then
     firebase functions:config:set "$CONFIG_VALUES"
 fi
 
-response=$(sh -c "firebase $*")
+response=$(firebase $*)
 
 if [ $? -eq 0 ]; then
   echo "$response"


### PR DESCRIPTION
The shell is returning a 0 exit code in all cases. This change unwraps the shell and allows us to use the actual exit code. Another stab at #134

POC:

```sh
#!/bin/bash
test=$(sh -c "exit 1")
secondTest=$(exit 1)

echo $test # 0
echo $secondTest # 1
```