### PR TITLE
Add missing jq command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable com
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
-RUN apt update && apt-get install -y openjdk-11-jre
+RUN apt update && apt-get install -y openjdk-11-jre jq
 
 RUN npm i -g npm@8.10.0
 RUN npm i -g firebase-tools@11.5.0


### PR DESCRIPTION
jq was accidentally removed by e268f4e but it is still used in entrypoint.sh