### PR TITLE
feat: add .env support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm i -g npm@8.10.0
 RUN npm i -g firebase-tools@11.16.0
 
 COPY LICENSE README.md /
-COPY .env /
+COPY .env* /
 COPY "entrypoint.sh" "/entrypoint.sh"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN npm i -g npm@8.10.0
 RUN npm i -g firebase-tools@11.16.0
 
 COPY LICENSE README.md /
+COPY .env /
 COPY "entrypoint.sh" "/entrypoint.sh"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ https://firebase.google.com/docs/hosting/github-integration
 
 * `CONFIG_VALUES` - **Optional**. The configuration values for Firebase function that would normally be set with `firebase functions:config:set [value]`. Example: `CONFIG_VALUES: stripe.secret_key=SECRET_KEY zapier.secret_key=SECRET_KEY`.
 
+
+### dotenv
+It's optionally possible to inject the env from an arbitrary `.env`, [as per documentation](https://firebase.google.com/docs/functions/config-env). Useful in particular when the Github Action environment (including secrets) need to be passed on to the Firebase app. 
+
+ATTENTION: It requires a step to copy the needed env inside a `.env.*` or simply `.env` file in the root folder.
+
 ## Example
 
 To authenticate with Firebase, and deploy to Firebase Hosting:


### PR DESCRIPTION
Firebase supports the injection of the `.env` configuration, as documented [here](https://firebase.google.com/docs/functions/config-env).

This turns out to be particularly useful in the context of Github Actions when for instance one would like to store all secrets in Github and pass them on to the firebase deploy script, or simply if willing to re-use the env from the Github Action inside the app. 

In such a case, it's just enough to copy the env inside a `.env` file and the firebase deploy script will pick it up and make it visible inside the app.

This PR adds support for such behaviour.