### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable com
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
-RUN apt update && apt-get install -y jq openjdk-11-jre
+RUN apt update && apt-get install --no-install-recommends -y jq openjdk-11-jre && rm -rf /var/lib/apt/lists/*;
 
-RUN npm i -g npm@8.10.0
-RUN npm i -g firebase-tools@11.18.0
+RUN npm i -g npm@8.10.0 && npm cache clean --force;
+RUN npm i -g firebase-tools@11.18.0 && npm cache clean --force;
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size and therefore slightly speed up the workflow.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 1.36 GB
* Image size after repair: 1.24 GB
* Difference: 124.99 MB (8.96%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,