### PR TITLE
Release v11.29.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.16.0-buster
 
-LABEL version="11.24.1"
+LABEL version="11.29.1"
 LABEL repository="https://github.com/w9jds/firebase-action"
 LABEL homepage="https://github.com/w9jds/firebase-action"
 LABEL maintainer="Jeremy Shore <w9jds@github.com>"
@@ -13,7 +13,7 @@ LABEL com.github.actions.color="gray-dark"
 RUN apt update && apt-get install --no-install-recommends -y jq openjdk-11-jre && rm -rf /var/lib/apt/lists/*;
 
 RUN npm i -g npm@8.10.0 && npm cache clean --force;
-RUN npm i -g firebase-tools@11.24.1 && npm cache clean --force;
+RUN npm i -g firebase-tools@11.29.1 && npm cache clean --force;
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"

--- a/action.yaml
+++ b/action.yaml
@@ -12,4 +12,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://w9jds/firebase-action:v11.24.1'
+  image: 'docker://w9jds/firebase-action:v11.29.1'


### PR DESCRIPTION
There was [a breaking change](https://cloud.google.com/functions/docs/release-notes#April_11_2023) on cloud functions.
firebase-tools has been [updated](https://github.com/firebase/firebase-tools/releases/tag/v11.27.0) to correspond it.
