### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _**Response has been removed for now as it caused loads of issues in the bash sc
     * If the deploy has scheduled functions, include the `Cloud Scheduler Admin` role.
     * If the deploy requires access to secrets, include the `Secret Manager Viewer` role.
     * If updating Firestore Rules, include the `Firebase Rules Admin` role.
+    * If the project is using Blocking functions (beforeCreate or beforeSignin) , include the `Firebase Functions Admin` role.
   * If updating Firestore Indexes, include the `Cloud Datastore Index Admin` role.
   * If deplying Hosting files, include the `Firebase Hosting Admin` role.
   * For more details: https://firebase.google.com/docs/hosting/github-integration


### PR DESCRIPTION
A deploy using blocking functions (beforeCreate or beforeSignin for Authentication with Identity Platform ) needs the functions admin role.

Deploying without the Administrator role results in the following error:


```
Functions deploy had errors with the following functions:
	auth-beforeCreateUser(europe-west1)

Unable to set the invoker for the IAM policy on the following functions:
	auth-beforeCreateUser(europe-west1)

Some common causes of this:

- You may not have the roles/functions.admin IAM role. Note that roles/functions.developer does not allow you to change IAM policies.

```

Adding the Functions admin role resolved the error.