### PR TITLE
feat: add GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ _**Response has been removed for now as it caused loads of issues in the bash sc
 
 * `FIREBASE_TOKEN` - **Required if GCP_SA_KEY is not set**. _**This method will soon be deprecated, use `GCP_SA_KEY` instead**_. The token to use for authentication. This token can be aquired through the `firebase login:ci` command.
 
+* `GOOGLE_APPLICATION_CREDENTIALS`
+
 * `PROJECT_ID` - **Optional**. To specify a specific project to use for all commands. Not required if you specify a project in your `.firebaserc` file. If you use this, you need to give `Viewer` permission roles to your service account otherwise the action will fail with authentication errors.
 
 * `PROJECT_PATH` - **Optional**. The path to the folder containing `firebase.json` if it doesn't exist at the root of your repository. e.g. `./my-app`.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ _**Response has been removed for now as it caused loads of issues in the bash sc
 
 * `FIREBASE_TOKEN` - **Required if GCP_SA_KEY is not set**. _**This method will soon be deprecated, use `GCP_SA_KEY` instead**_. The token to use for authentication. This token can be aquired through the `firebase login:ci` command.
 
-* `GOOGLE_APPLICATION_CREDENTIALS` - **Required if GCP_SA_KEY or FIREBASE_TOKEN is not set**.the location of a credential JSON file. 
-  * For more details: https://cloud.google.com/docs/authentication/application-default-credentials#GAC
+* `GOOGLE_APPLICATION_CREDENTIALS` - **Required if GCP_SA_KEY or FIREBASE_TOKEN is not set**. the location of a credential JSON file. For more details: https://cloud.google.com/docs/authentication/application-default-credentials#GAC
 
 * `PROJECT_ID` - **Optional**. To specify a specific project to use for all commands. Not required if you specify a project in your `.firebaserc` file. If you use this, you need to give `Viewer` permission roles to your service account otherwise the action will fail with authentication errors.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ _**Response has been removed for now as it caused loads of issues in the bash sc
 
 * `FIREBASE_TOKEN` - **Required if GCP_SA_KEY is not set**. _**This method will soon be deprecated, use `GCP_SA_KEY` instead**_. The token to use for authentication. This token can be aquired through the `firebase login:ci` command.
 
-* `GOOGLE_APPLICATION_CREDENTIALS`
+* `GOOGLE_APPLICATION_CREDENTIALS` - **Required if GCP_SA_KEY or FIREBASE_TOKEN is not set**.the location of a credential JSON file. 
+  * For more details: https://cloud.google.com/docs/authentication/application-default-credentials#GAC
 
 * `PROJECT_ID` - **Optional**. To specify a specific project to use for all commands. Not required if you specify a project in your `.firebaserc` file. If you use this, you need to give `Viewer` permission roles to your service account otherwise the action will fail with authentication errors.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if [ -z "$FIREBASE_TOKEN" ] && [ -z "$GCP_SA_KEY" ]; then
-  echo "Either FIREBASE_TOKEN or GCP_SA_KEY is required to run commands with the firebase cli"
+if [ -z "$FIREBASE_TOKEN" ] && [ -z "$GCP_SA_KEY" ] && [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+  echo "Either FIREBASE_TOKEN or GCP_SA_KEY or GOOGLE_APPLICATION_CREDENTIALS is required to run commands with the firebase cli"
   exit 126
 fi
 


### PR DESCRIPTION
I want to use GOOGLE_APPLICATION_CREDENTIALS set in another step.

When using [google-github-actions/auth@v2](https://github.com/google-github-actions/auth), GOOGLE_APPLICATION_CREDENTIALS is set.
I want to use that action to support authentication using Workload Identity.