### PR TITLE
Allow running multiple args sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ If you want a more flexible implementation, an early version of a rewrite is ava
 
 ## Inputs
 
-* `args` - **Required**. This is the arguments you want to use for the `firebase` cli
+* `args` - **Required**. These are the arguments you want to use for the
+  `firebase` cli. Arguments will be treated sequentially.
 
 ## Outputs
 
@@ -81,7 +82,7 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy --only hosting
+          args: ["deploy --only hosting"]
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 ```
@@ -94,13 +95,13 @@ Alternatively:
 
 
 If you have multiple hosting environments you can specify which one in the args line.
-e.g. `args: deploy --only hosting:[environment name]`
+e.g. `args: ["deploy --only hosting:<environment name>"]`
 
 If you want to add a message to a deployment (e.g. the Git commit message) you need to take extra care and escape the quotes or the YAML breaks.
 
 ```yaml
         with:
-          args: deploy --message \"${{ github.event.head_commit.message }}\"
+          args: ["deploy --message \"${{ github.event.head_commit.message }}\""]
 ```
 
 ## Alternate versions
@@ -111,7 +112,7 @@ Starting with version v2.1.2 each version release will point to a versioned dock
   name: Deploy to Firebase
   uses: docker://w9jds/firebase-action:master
   with:
-    args: deploy --only hosting
+    args: ["deploy --only hosting"]
   env:
     FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,14 @@ if [ -n "$CONFIG_VALUES" ]; then
     firebase functions:config:set $CONFIG_VALUES
 fi
 
-sh -c "firebase $*"
+for arg in "$@"; do
+  echo "Running: firebase $arg"
+  firebase "$arg"
+  if [ $? -ne 0 ]; then
+    echo "Error: Command 'firebase $arg' failed."
+    exit 1
+  fi
+done
 
 # response=$(firebase $*)
 


### PR DESCRIPTION
I would like to use this action for other things than just running a deploy action.

One specific use case I have in hand is to be able to run emulator with the CLI, and for this, I would like to run e.g.: `firebase setup:emulators:firestore && firebase setup:emulators:database` and finally `firebase emulators:start`.

This change enables support for the firebase-action to sequentially run `args`.

I briefly checked the tests, but did not see I would break anything. Please let me know if I missed something or there is a better way to fulfill the requirement I have at hand. 
