### PR TITLE
fix: switch base image from node:20-buster to node:20-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-buster
+FROM node:20-alpine
 
 LABEL version="14.11.0"
 LABEL repository="https://github.com/w9jds/firebase-action"
@@ -10,7 +10,7 @@ LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable com
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
-RUN apt update && apt-get install --no-install-recommends -y jq openjdk-11-jre && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add --no-cache jq openjdk11-jre
 
 RUN npm i -g npm@8.10.0 && npm cache clean --force
 RUN npm i -g firebase-tools@14.11.0 && npm cache clean --force


### PR DESCRIPTION
- Changes node:20-buster image to node:20-alpine image
- Fixes error on Github Action at pulling Dockerfile